### PR TITLE
Fix docs and broken "postinstall" script in the package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,6 @@ jobs:
           command: |
             rm -rf node_modules package-lock.json
             npm install
-            npm run build:dev
-            npm run test:install
       - run:
           name: Running all unit tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
           command: |
             rm -rf node_modules package-lock.json
             npm install
+            npm run build:dev
+            npm run test:install
       - run:
           name: Running all unit tests
           command: |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Here is what the package.json would look like:
 {
     "name": "mypackage",
     "scripts": {
-        "postinstall": "node conditional-install"
+        "postinstall": "conditional-install"
     },
     "devDependencies": {
         "conditional-install": "^1.0.0"

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Here is what the package.json would look like:
     "scripts": {
         "postinstall": "conditional-install"
     },
-    "devDependencies": {
+    "dependencies": {
         "conditional-install": "^1.0.0"
     },
     "conditionalDependencies": {
         "process.version >= 14.0.0": {
-            "jest": "^29.0.0"
+            "example-package": "^29.0.0"
         },
         "process.version < 14.0.0": {
-            "jest": "^26.0.0"
+            "example-package": "^26.0.0"
         }
     }
 }
@@ -152,9 +152,11 @@ Conditional Dev Dependencies
 
 If you put "conditional-install" into the postinstall script, both npm and yarn will run the
 conditional installation whether you are doing `npm install` locally in your cloned git repo, or
-including your package into another package from the npm repository. In some cases, you only want
-to do conditional installation when running locally. To do that, put "conditional-install" into
-the "prepare" script instead:
+including your package into another package from the npm repository.
+
+In some cases, you only want to do conditional installation when running locally during development.
+To do that, put "conditional-install" into the "prepare" script instead and include "conditional-install"
+in your `devDependencies` instead:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -147,6 +147,35 @@ Example of a conditional expression using more complex syntax:
     }
 ```
 
+Conditional Dev Dependencies
+--------
+
+If you put "conditional-install" into the postinstall script, both npm and yarn will run the
+conditional installation whether you are doing `npm install` locally in your cloned git repo, or
+including your package into another package from the npm repository. In some cases, you only want
+to do conditional installation when running locally. To do that, put "conditional-install" into
+the "prepare" script instead:
+
+```json
+{
+    "name": "mypackage",
+    "scripts": {
+        "prepare": "conditional-install"
+    },
+    "devDependencies": {
+        "conditional-install": "^1.0.0"
+    },
+    "conditionalDependencies": {
+        "process.version >= 14.0.0": {
+            "jest": "^29.0.0"
+        },
+        "process.version < 14.0.0": {
+            "jest": "^26.0.0"
+        }
+    }
+}
+```
+
 See Also
 --------
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ See Also
 
 ## License
 
-Copyright © 2023, JEDLSoft
+Copyright © 2023-2024, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -174,6 +174,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v1.0.1
+
+- fixed a broken "postinstall" script in the package.json
+- updated documentation
 
 ### v1.0.0
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
         "debug:web": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/.bin/karma start --reporters dots",
         "clean": "git clean -f -d src test; rm -rf lib",
         "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/conditionalInstall.md",
-        "doc:html": "jsdoc -c jsdoc.json"
+        "doc:html": "jsdoc -c jsdoc.json",
+        "postinstall": "node src/index.js"
     },
     "devDependencies": {
         "@babel/core": "^7.23.5",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
         "debug:web": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/.bin/karma start --reporters dots",
         "clean": "git clean -f -d src test; rm -rf lib",
         "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/conditionalInstall.md",
-        "doc:html": "jsdoc -c jsdoc.json",
-        "postinstall": "node src/index.js"
+        "doc:html": "jsdoc -c jsdoc.json"
     },
     "devDependencies": {
         "@babel/core": "^7.23.5",

--- a/package.json
+++ b/package.json
@@ -83,13 +83,13 @@
         "jsdoc": "^4.0.2",
         "jsdoc-to-markdown": "^8.0.0",
         "load-grunt-tasks": "^5.1.0",
-        "npm-run-all": "^4.1.5",
-        "semver": "^7.5.4"
+        "npm-run-all": "^4.1.5"
     },
     "dependencies": {
         "core-js": "^3.0.0",
         "expressionparser": "^1.1.5",
-        "node-fetch": "^2.0.0"
+        "node-fetch": "^2.0.0",
+        "semver": "^7.5.4"
     },
     "conditionalDependencies": {
         "process.versions.node < 14.0.0": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "conditional-install",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "bin": {
@@ -62,8 +62,7 @@
         "debug:web": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/.bin/karma start --reporters dots",
         "clean": "git clean -f -d src test; rm -rf lib",
         "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/conditionalInstall.md",
-        "doc:html": "jsdoc -c jsdoc.json",
-        "postinstall": "npm-run-all build test:install"
+        "doc:html": "jsdoc -c jsdoc.json"
     },
     "devDependencies": {
         "@babel/core": "^7.23.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
         "debug:web": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/.bin/karma start --reporters dots",
         "clean": "git clean -f -d src test; rm -rf lib",
         "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/conditionalInstall.md",
-        "doc:html": "jsdoc -c jsdoc.json"
+        "doc:html": "jsdoc -c jsdoc.json",
+        "prepare": "npm-run-all build:dev test:install"
     },
     "devDependencies": {
         "@babel/core": "^7.23.5",


### PR DESCRIPTION
- could not install v1.0.0 without it trying to build and test everything, which wouldn't work anyways
    - now runs itself to install the proper version of jest during the circleci setup before running the tests
    - added semver to the dependencies instead of devDependencies because it is an actual dependency
- minor fix to the documentation
