### PR TITLE
Don't run the npm scripts while installing the conditional deps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,9 +49,6 @@ module.exports = function(grunt) {
                         "corejs": 3
                     }
                 ]],
-                plugins: [
-                    "add-module-exports"
-                ],
                 compact: !debug,
                 minified: !debug
             },

--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ limitations under the License.
 ### v1.0.2
 
 - now while installing the conditional dependencies, it ignores any automatically run scripts you may have set up
-  in your package.json . The original run of npm install will run those scripts properly have the conditional
-  install is complete.
+  in your package.json . The original run of npm install will run those scripts properly once the conditional
+  install is complete. This prevents a recursive install loop.
 
 ### v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ limitations under the License.
 - now while installing the conditional dependencies, it ignores any automatically run scripts you may have set up
   in your package.json . The original run of npm install will run those scripts properly once the conditional
   install is complete. This prevents a recursive install loop.
+- tests now run properly on node 22
 
 ### v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.0.2
+
+- now while installing the conditional dependencies, it ignores any automatically run scripts you may have set up
+  in your package.json . The original run of npm install will run those scripts properly have the conditional
+  install is complete.
+
 ### v1.0.1
 
 - fixed a broken "postinstall" script in the package.json

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,9 +31,6 @@ if (semver.lte(process.versions.node, 'v16.0.0')) {
                 "/node_modules/"
             ],
             plugins: [
-                "@babel/plugin-proposal-optional-chaining",
-                "transform-import-meta",
-                "add-module-exports",
                 ["module-resolver", {
                     "root": "test",
                     // map the src dir to the lib dir so we can

--- a/package.json
+++ b/package.json
@@ -67,13 +67,9 @@
     },
     "devDependencies": {
         "@babel/core": "^7.23.5",
-        "@babel/plugin-proposal-optional-chaining": "^7.21.0",
         "@babel/plugin-transform-modules-commonjs": "^7.23.3",
         "@babel/preset-env": "^7.23.5",
         "@babel/runtime": "^7.23.5",
-        "babel-plugin-add-module-exports": "^1.0.4",
-        "babel-plugin-module-resolver": "^5.0.0",
-        "babel-plugin-transform-import-meta": "^2.2.1",
         "docdash": "^2.0.2",
         "grunt": "^1.6.1",
         "grunt-babel": "^8.0.0",
@@ -102,6 +98,12 @@
             "jest": "^29.0.0",
             "jest-mock": "^29.0.0",
             "expect": "^29.0.0"
+        },
+        "process.versions.node < 16.0.0": {
+            "babel-plugin-module-resolver": "^4.0.0"
+        },
+        "process.versions.node >= 16.0.0": {
+            "babel-plugin-module-resolver": "^5.0.0"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "conditional-install",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "bin": {

--- a/src/NodeCompat.js
+++ b/src/NodeCompat.js
@@ -34,6 +34,8 @@ const ECMAScriptAliases = {
     "ES12": "ES2021",
     "ES13": "ES2022",
     "ES14": "ES2023",
+    "ES15": "ES2024",
+    "ES16": "ES2025",
     "ESM": "ES2015",
     "CJS": "ES2009"
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js - implement conditional package installation
  *
- * Copyright © 2023 JEDLSoft
+ * Copyright © 2023-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ try {
         const conditions = new Conditions(pkg.conditionalDependencies, nc);
         const packages = conditions.getInstallInstructions();
         if (packages.length) {
-            const command = `npm install --no-save ${packages}`;
+            const command = `npm install --no-save --ignore-scripts ${packages}`;
             console.log(command);
             execSync(command);
         }

--- a/test/NodeCompat.test.js
+++ b/test/NodeCompat.test.js
@@ -19,6 +19,7 @@
 
 import NodeCompat from "../src/NodeCompat.js";
 import fs from 'fs';
+import semver from 'semver';
 
 describe("testing the node compatibility check object", () => {
     test("that the constructor works okay", () => {
@@ -54,9 +55,14 @@ describe("testing the node compatibility check object", () => {
         expect.assertions(3);
 
         const nc = new NodeCompat();
+        // this gets its information from the current version of node that we are running on
         return nc.getVersionInfo().then(() => {
             expect(nc.init).toBeTruthy();
-            expect(nc.supportsFeature("Iterator.prototype.map")).toBeFalsy();
+            if (semver.lt(process.versions.node, "v22.0.0")) {
+                expect(nc.supportsFeature("Iterator.prototype.map")).toBeFalsy();
+            } else {
+                expect(nc.supportsFeature("Iterator.prototype.map")).toBeTruthy();
+            }
             expect(nc.supportsFeature("DataView.prototype.getBigInt64")).toBeTruthy();
         });
     });

--- a/test/NodeCompat.test.js
+++ b/test/NodeCompat.test.js
@@ -34,7 +34,7 @@ describe("testing the node compatibility check object", () => {
         const nc = new NodeCompat();
         expect(nc.init).toBeFalsy();
         expect(() => {
-            nc.supportsFeature("Iterator.prototype.map")
+            nc.supportsFeature("Iterator.prototype.map");
         }).toThrow();
         expect(() => {
             nc.supportsEsVersion("ES2015")


### PR DESCRIPTION
What was happening is that it would do the subinstall of the conditional dependency and thereby run the postinstall script again, which would attempt to install the conditional dependency again, etc. etc. in a recursive hellscape of installations.

Solution is simple: don't run the scripts when installing the conditional packages. Let the outer npm run do all the scripts instead.